### PR TITLE
fix shared paths and forward call

### DIFF
--- a/src/Train.ipynb
+++ b/src/Train.ipynb
@@ -624,7 +624,7 @@
     "        layers_per_block=2,\n",
     "        sample_size=256,\n",
     "    )\n",
-    "    ckpt = torch.load('/weka/proj-fmri/paulscotti/MindEyeV2/models/sd_image_var_autoenc.pth')\n",
+    "    ckpt = torch.load('/weka/proj-fmri/shared/cache/sd_var_enc/sd_image_var_autoenc.pth')\n",
     "    autoenc.load_state_dict(ckpt)\n",
     "    \n",
     "    autoenc.eval()\n",
@@ -633,7 +633,7 @@
     "    utils.count_params(autoenc)\n",
     "    \n",
     "    from autoencoder.convnext import ConvnextXL\n",
-    "    cnx = ConvnextXL('/weka/proj-fmri/paulscotti/MindEyeV2/models/convnext_xlarge_alpha0.75_fullckpt.pth')\n",
+    "    cnx = ConvnextXL('/weka/proj-fmri/shared/cache/convnextv2/convnext_xlarge_alpha0.75_fullckpt.pth')\n",
     "    cnx.requires_grad_(False)\n",
     "    cnx.eval()\n",
     "    cnx.to(device)\n",
@@ -812,7 +812,7 @@
     "        \n",
     "    def forward(self, x):\n",
     "        # make empty tensors\n",
-    "        c,b = torch.Tensor([0.]), torch.Tensor([[0.],[0.]]), torch.Tensor([0.])\n",
+    "        c,b = torch.Tensor([0.]), torch.Tensor([[0.],[0.]])\n",
     "        \n",
     "        # Mixer blocks\n",
     "        residual1 = x\n",
@@ -1936,9 +1936,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mindeye",
+   "display_name": "fmri2",
    "language": "python",
-   "name": "mindeye"
+   "name": "fmri2"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
**Changelog**

1. Add shared paths for `sd_image_var_autoenc` and `convnext_xlarge_alpha0.75_fullckpt`
2. Fix ValueError in forward call of BrainNetwork