### PR TITLE
Fix: open-clip-torch version

### DIFF
--- a/src/setup.sh
+++ b/src/setup.sh
@@ -8,6 +8,6 @@ pip install --upgrade pip
 python3.11 -m venv fmri
 source fmri/bin/activate
 
-pip install numpy matplotlib==3.8.2 jupyter jupyterlab_nvdashboard jupyterlab tqdm scikit-image==0.22.0 accelerate==0.24.1 webdataset==0.2.73 pandas==2.2.0 einops ftfy regex kornia==0.7.1 h5py==3.10.0 open_clip_torch torchvision==0.16.0 torch==2.1.0 transformers==4.37.2 xformers==0.0.22.post7 torchmetrics==1.3.0.post0 diffusers==0.23.0 deepspeed==0.13.1 wandb omegaconf==2.3.0 pytorch-lightning==2.0.1 sentence-transformers==2.5.1 evaluate==0.4.1 nltk==3.8.1 rouge_score==0.1.2 umap==0.1.1
+pip install numpy matplotlib==3.8.2 jupyter jupyterlab_nvdashboard jupyterlab tqdm scikit-image==0.22.0 accelerate==0.24.1 webdataset==0.2.73 pandas==2.2.0 einops ftfy regex kornia==0.7.1 h5py==3.10.0 open_clip_torch==2.24.0 torchvision==0.16.0 torch==2.1.0 transformers==4.37.2 xformers==0.0.22.post7 torchmetrics==1.3.0.post0 diffusers==0.23.0 deepspeed==0.13.1 wandb omegaconf==2.3.0 pytorch-lightning==2.0.1 sentence-transformers==2.5.1 evaluate==0.4.1 nltk==3.8.1 rouge_score==0.1.2 umap==0.1.1
 pip install git+https://github.com/openai/CLIP.git --no-deps
 pip install dalle2-pytorch


### PR DESCRIPTION
The `open-clip-torch` package updates to the latest version, which causes a runtime error during enhanced recon due to an attention mask issue:  

```
RuntimeError: The shape of the 2D attn_mask is torch.Size([77, 77]), but should be (1, 1).
```

After checking for compatibility, I found that version `2.24.0` resolves this issue, so I’ve added the fix in `setup.sh`.